### PR TITLE
Use O_TMPFILE on Linux

### DIFF
--- a/tmpfile.go
+++ b/tmpfile.go
@@ -1,4 +1,4 @@
-// +build !windows
+// +build !windows,!linux
 
 package tmpfile
 

--- a/tmpfile_linux.go
+++ b/tmpfile_linux.go
@@ -4,23 +4,26 @@ import (
 	"os"
 )
 
-// O_TMPFILE is a flag indicating that the open(2) syscall should create
+// oTMPFILE is a flag indicating that the open(2) syscall should create
 // an unnamed temporary file. When used, the pathname argument to open
 // should be a directory instead of a filename. An unnamed inode will be
 // created in that directory's filesystem. Anything written to the
 // resulting file will be lost when the last file descriptor is closed,
 // unless the file is given a name.
 //
-// O_TMPFILE must be specified with one of os.O_RDWR or os.O_WRONLY and,
+// Usually known as O_TMPFILE, but that name is not used here to conform
+// with Go naming conventions.
+//
+// oTMPFILE must be specified with one of os.O_RDWR or os.O_WRONLY and,
 // optionally, os.O_EXCL. If os.O_EXCL is _not_ specified, then
 // "golang.org/x/sys/unix".Linkat() can be used to link the temporary
 // file into the filesystem, making it permanent.
 //
 // Available on Linux 3.11 and later.
-const O_TMPFILE = 0x410000
+const oTMPFILE = 0x410000
 
 // New creates a new unnamed temporary file in the directory dir using
-// O_TMPFILE so that it never needs to be unlinked with os.Remove().
+// oTMPFILE so that it never needs to be unlinked with os.Remove().
 // The pattern argument is ignored and exists for interface compatibility.
 //
 // If dir is the empty string it will default to using os.TempDir() as the
@@ -32,5 +35,5 @@ func New(dir, pattern string) (f *os.File, err error) {
 	if dir == "" {
 		dir = os.TempDir()
 	}
-	return os.OpenFile(dir+"/.", os.O_RDWR|O_TMPFILE, 0600)
+	return os.OpenFile(dir+"/.", os.O_RDWR|oTMPFILE, 0600)
 }

--- a/tmpfile_linux.go
+++ b/tmpfile_linux.go
@@ -1,0 +1,36 @@
+package tmpfile
+
+import (
+	"os"
+)
+
+// O_TMPFILE is a flag indicating that the open(2) syscall should create
+// an unnamed temporary file. When used, the pathname argument to open
+// should be a directory instead of a filename. An unnamed inode will be
+// created in that directory's filesystem. Anything written to the
+// resulting file will be lost when the last file descriptor is closed,
+// unless the file is given a name.
+//
+// O_TMPFILE must be specified with one of os.O_RDWR or os.O_WRONLY and,
+// optionally, os.O_EXCL. If os.O_EXCL is _not_ specified, then
+// "golang.org/x/sys/unix".Linkat() can be used to link the temporary
+// file into the filesystem, making it permanent.
+//
+// Available on Linux 3.11 and later.
+const O_TMPFILE = 0x410000
+
+// New creates a new unnamed temporary file in the directory dir using
+// O_TMPFILE so that it never needs to be unlinked with os.Remove().
+// The pattern argument is ignored and exists for interface compatibility.
+//
+// If dir is the empty string it will default to using os.TempDir() as the
+// directory for storing the temporary files.
+//
+// The target directory dir must already exist or an error will result. New
+// does not create or remove the directory dir.
+func New(dir, pattern string) (f *os.File, err error) {
+	if dir == "" {
+		dir = os.TempDir()
+	}
+	return os.OpenFile(dir+"/.", os.O_RDWR|O_TMPFILE, 0600)
+}


### PR DESCRIPTION
`O_TMPFILE` is pretty nice for tempfile hygiene, because there is no possibility of the file not getting removed- even if the system crashes immediately after open(). The main reason you might _not_ want this change is that it required a few changes to the tests, because the file doesn't have any name and therefore can't conform to the expected pattern. Also, `os.Stat(f.Name())` succeeds because `f.Name()` can only give you the name of the directory where the tempfile's inode lives.